### PR TITLE
Message Queue Return

### DIFF
--- a/adafruit_azureiot.py
+++ b/adafruit_azureiot.py
@@ -91,8 +91,8 @@ class IOT_Hub:
 
     # Cloud-to-Device Messaging
     def get_hub_message(self):
-        """Returns a message from a Microsoft Azure IoT Hub (Cloud-to-Device), or -1
-        if the message queue is empty.
+        """Returns a message from a Microsoft Azure IoT Hub (Cloud-to-Device).
+        Returns None if the message queue is empty.
         NOTE: HTTP Cloud-to-Device messages are throttled. Poll every 25+ minutes.
         """
         reject_message = True
@@ -102,7 +102,7 @@ class IOT_Hub:
                                                                              AZ_API_VER)
         data = self._get(path, is_c2d=True)
         if data == 204: # device's message queue is empty
-            return -1
+            return None
         etag = data[1]['etag']
         if etag: # either complete or nack the message
             reject_message = False
@@ -113,7 +113,7 @@ class IOT_Hub:
             del_status = self._delete(path_complete)
         if del_status == 204:
             return data[0]
-        return -1
+        return None
 
     # Device-to-Cloud Messaging
     def send_device_message(self, message):

--- a/examples/azureiot_simpletest.py
+++ b/examples/azureiot_simpletest.py
@@ -43,7 +43,7 @@ print('Data Sent!')
 # Microsoft suggests a polling interval of the below code for every 25 minutes.
 print('Receiving a message from an Azure IoT Hub...')
 message = hub.get_hub_message()
-if message == -1:
+if message == None:
     print('IoT Hub Message Queue is empty!')
 else:
     print(message)

--- a/examples/azureiot_simpletest.py
+++ b/examples/azureiot_simpletest.py
@@ -43,7 +43,7 @@ print('Data Sent!')
 # Microsoft suggests a polling interval of the below code for every 25 minutes.
 print('Receiving a message from an Azure IoT Hub...')
 message = hub.get_hub_message()
-if message == None:
+if message is None:
     print('IoT Hub Message Queue is empty!')
 else:
     print(message)


### PR DESCRIPTION
Message queue now returns `None` if no messages are in the queue, instead of returning `-1`. Example updated to reflect this change.

https://github.com/adafruit/Adafruit_CircuitPython_AzureIoT/pull/1#pullrequestreview-244532741