### PR TITLE
Removing will set to fix breaking miniMQTT changes

### DIFF
--- a/adafruit_azureiot/iot_mqtt.py
+++ b/adafruit_azureiot/iot_mqtt.py
@@ -138,7 +138,6 @@ class IoTMQTT:
         self._mqtts.on_disconnect = self._on_disconnect
 
         # initiate the connection using the adafruit_minimqtt library
-        self._mqtts.last_will()
         self._mqtts.connect()
 
     # pylint: disable=C0103, W0613


### PR DESCRIPTION
The `last_will` method on the miniMQTT library has been renamed, so removing the call for now to set the will to fix the break.