### PR TITLE
add logging to requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bundles
 dist
 **/*.egg-info
 .vscode/settings.json
+.python_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+Adafruit-CircuitPython-Binascii
+Adafruit-CircuitPython-Logging
 Adafruit-CircuitPython-miniMQTT
 Adafruit-CircuitPython-Requests
-Adafruit-CircuitPython-Binascii


### PR DESCRIPTION
Many moons ago I did a PR to add adafruit_logging to the readme, this adds it to the requirements.txt

Also added .python_version to the .gitignore