### PR TITLE
CPSockets Updates

### DIFF
--- a/adafruit_azureiot/constants.py
+++ b/adafruit_azureiot/constants.py
@@ -13,10 +13,10 @@ This file is for maintaining Microsoft Azure IoT constants that could be changed
 """
 
 # The version of the IoT Central MQTT API this code is built against
-IOTC_API_VERSION = "2016-11-14"
+IOTC_API_VERSION = "2018-06-30"
 
 # The version of the Azure Device Provisioning Service this code is built against
-DPS_API_VERSION = "2018-11-01"
+DPS_API_VERSION = "2019-03-31"
 
 # The Azure Device Provisioning service endpoint that this library uses to provision IoT Central devices
 DPS_END_POINT = "global.azure-devices-provisioning.net"

--- a/adafruit_azureiot/device_registration.py
+++ b/adafruit_azureiot/device_registration.py
@@ -59,7 +59,13 @@ class DeviceRegistration:
                 )
 
     def __init__(
-        self, socket, id_scope: str, device_id: str, key: str, logger: Logger = None
+        self,
+        socket,
+        iface,
+        id_scope: str,
+        device_id: str,
+        key: str,
+        logger: Logger = None,
     ):
         """Creates an instance of the device registration service
         :param socket: The network socket
@@ -73,7 +79,8 @@ class DeviceRegistration:
         self._key = key
         self._logger = logger if logger is not None else logging.getLogger("log")
 
-        requests.set_socket(socket)
+        socket.set_interface(iface)
+        requests.set_socket(socket, iface)
 
     def _loop_assign(self, operation_id, headers) -> str:
         uri = "https://%s/%s/registrations/%s/operations/%s?api-version=%s" % (

--- a/adafruit_azureiot/iot_mqtt.py
+++ b/adafruit_azureiot/iot_mqtt.py
@@ -119,9 +119,8 @@ class IoTMQTT:
             keep_alive=120,
             is_ssl=True,
             client_id=self._device_id,
-            log=True,
         )
-
+        self._mqtts.logger = self._logger
         self._mqtts.logger.setLevel(self._logger.getEffectiveLevel())
 
         # set actions to take throughout connection lifecycle

--- a/adafruit_azureiot/iotcentral_device.py
+++ b/adafruit_azureiot/iotcentral_device.py
@@ -136,7 +136,12 @@ class IoTCentralDevice(IoTMQTTCallback):
         :raises RuntimeError: if the internet connection is not responding or is unable to connect
         """
         self._device_registration = DeviceRegistration(
-            self._socket, self._id_scope, self._device_id, self._key, self._logger
+            self._socket,
+            self._iface,
+            self._id_scope,
+            self._device_id,
+            self._key,
+            self._logger,
         )
 
         token_expiry = int(time.time() + self._token_expires)


### PR DESCRIPTION
will fix #24 (hopefully, someday...) 

All the IoT Hub Examples are working.

The IoT Central  examples all fail and are unable to connect. 
You can see that the device registration works, it gets back iot central's hub.
But when connecting, it fails with OSError: 23 within the try in _get_connect_socket

```python
20914.2: INFO - Establishing a SECURE SSL connection to iotc-snip-snip-snip-snip-snip.azure-devices.net:8883
Traceback (most recent call last):
  File "code.py", line 122, in <module>
  File "/lib/adafruit_azureiot/iotcentral_device.py", line 163, in connect
  File "/lib/adafruit_azureiot/iot_mqtt.py", line 387, in connect
  File "/lib/adafruit_azureiot/iot_mqtt.py", line 133, in _create_mqtt_client
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 439, in connect
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 273, in _get_connect_socket
RuntimeError: Repeated socket failures
```

I'm now wondering if the IoT Central API changed... 