### PR TITLE
Add Adafruit Logging as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@
 
 Adafruit-Blinka
 Adafruit-CircuitPython-miniMQTT
+Adafruit-CircuitPython-Logging
 Adafruit-CircuitPython-Binascii

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@
 Adafruit-Blinka
 Adafruit-CircuitPython-miniMQTT
 Adafruit-CircuitPython-Logging
+Adafruit-CircuitPython-Requests
 Adafruit-CircuitPython-Binascii

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "Adafruit-Blinka",
         "Adafruit-CircuitPython-miniMQTT",
+        "Adafruit-CircuitPython-Logging",
         "Adafruit-CircuitPython-Requests",
         "Adafruit-CircuitPython-Binascii",
     ],


### PR DESCRIPTION
Depends on https://github.com/adafruit/Adafruit_CircuitPython_Logging/pull/26.