### PR TITLE
Fix SSL and set_socket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ To create an Azure IoT Hub instance or an Azure IoT Central app, you will need a
 ESP32 AirLift Networking
 ========================
 
+*NOTE* currently the ESP32 AirLift is not supported due to the requirment of `ssl`, which is only on boards with native WiFi.
+
 To use this library, you will need to create an ESP32_SPI WifiManager, connected to WiFi. You will also need to set the current time, as this is used to generate time-based authentication keys. One way to do this is with the following code:
 
 .. code-block:: python

--- a/adafruit_azureiot/device_registration.py
+++ b/adafruit_azureiot/device_registration.py
@@ -112,7 +112,7 @@ class DeviceRegistration:
             " - device_registration :: connect :: created mqtt client. connecting.."
         )
         while not self._auth_response_received:
-            self._mqtt.loop()
+            self._mqtt.loop(2)
 
         self._logger.info(
             " - device_registration :: connect :: on_connect must be fired. Connected ?"
@@ -139,7 +139,7 @@ class DeviceRegistration:
         while self._operation_id is None and retry < 10:
             time.sleep(1)
             retry += 1
-            self._mqtt.loop()
+            self._mqtt.loop(2)
 
         if self._operation_id is None:
             raise DeviceRegistrationError(
@@ -159,7 +159,7 @@ class DeviceRegistration:
         while self._hostname is None and retry < 10:
             time.sleep(1)
             retry += 1
-            self._mqtt.loop()
+            self._mqtt.loop(2)
 
         if self._hostname is None:
             raise DeviceRegistrationError(
@@ -194,15 +194,15 @@ class DeviceRegistration:
             "&skn=registration"
         )
 
-        MQTT.set_socket(self._socket, self._iface)
-
         self._mqtt = MQTT.MQTT(
             broker=constants.DPS_END_POINT,
+            port=8883,
             username=username,
             password=auth_string,
-            port=8883,
-            keep_alive=120,
             client_id=self._device_id,
+            is_ssl=True,
+            keep_alive=120,
+            socket_pool=self._socket,
             ssl_context=ssl.create_default_context(),
         )
 

--- a/adafruit_azureiot/iot_mqtt.py
+++ b/adafruit_azureiot/iot_mqtt.py
@@ -120,8 +120,6 @@ class IoTMQTT:
         )
 
     def _create_mqtt_client(self) -> None:
-        MQTT.set_socket(self._socket, self._iface)
-
         log_text = (
             f"- iot_mqtt :: _on_connect :: username = {self._username}, password = "
             + f"{self._passwd}"
@@ -135,11 +133,13 @@ class IoTMQTT:
 
         self._mqtts = MQTT.MQTT(
             broker=self._hostname,
+            port=8883,
             username=self._username,
             password=self._passwd,
-            port=8883,
-            keep_alive=120,
             client_id=self._device_id,
+            is_ssl=True,
+            keep_alive=120,
+            socket_pool=self._socket,
             ssl_context=ssl.create_default_context(),
         )
 
@@ -457,7 +457,7 @@ class IoTMQTT:
         if not self.is_connected():
             return
 
-        self._mqtts.loop()
+        self._mqtts.loop(2)
         gc.collect()
 
     def send_device_to_cloud_message(


### PR DESCRIPTION
Fix SSL and update for removal of MiniMQTT legacy `set_socket` removal.

fixes: https://github.com/adafruit/Adafruit_CircuitPython_AzureIoT/issues/60

Tested with which is a stripped down version of the learn guide: [Getting Started with Microsoft Azure and CircuitPython](https://learn.adafruit.com/getting-started-with-microsoft-azure-and-circuitpython):
```
import time
import json
import supervisor
import rtc
import socketpool
import wifi
import adafruit_ntp
from adafruit_azureiot import IoTCentralDevice
import adafruit_logging

logger = adafruit_logging.Logger("log", 0)

try:
    from secrets import secrets
except ImportError:
    print("WiFi secrets are kept in secrets.py, please add them there!")
    raise

print("Connecting to WiFi...")
wifi.radio.connect(secrets["ssid"], secrets["password"])
print("Connected to WiFi!")

pool = socketpool.SocketPool(wifi.radio)
ntp = adafruit_ntp.NTP(pool, tz_offset=-4)
rtc.RTC().datetime = ntp.datetime

if time.localtime().tm_year < 2022:
    print("Setting System Time in UTC")
    rtc.RTC().datetime = ntp.datetime

else:
    print("Year seems good, skipping set time.")

esp = None
pool = socketpool.SocketPool(wifi.radio)
device = IoTCentralDevice(
    pool, esp, secrets["id_scope"], secrets["device_id"], secrets["device_primary_key"], logger=logger,
)

print("Connecting to Azure IoT Central...")
device.connect()
print("Connected to Azure IoT Central!")

azure_clock = 10
i = 0

while True:
    try:
        if azure_clock >= 10:
            i += 1
            print("getting ntp date/time")
            cal = ntp.datetime
            time.sleep(2)
            print("getting msg")
            message = {"value": i}
            print("sending json")
            device.send_telemetry(json.dumps(message))
            print("data sent")
            azure_clock = 0
        else:
            azure_clock += 1
        device.loop()
    except (ValueError, RuntimeError, OSError, ConnectionError) as e:
        print("Network error, reconnecting\n", str(e))
        supervisor.reload()
        continue

    time.sleep(1)
    print(azure_clock)
```
