### PR TITLE
Fix ESP32SPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,10 +49,8 @@ This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
 * `Adafruit CircuitPython BinASCII <https://github.com/adafruit/Adafruit_CircuitPython_Binascii>`_
-* `Adafruit CircuitPython ConnectionManager <https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager/>`_
 * `Adafruit CircuitPython Logging <https://github.com/adafruit/Adafruit_CircuitPython_Logging>`_
 * `Adafruit CircuitPython MiniMQTT <https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT>`_
-* `Adafruit CircuitPython Requests <https://github.com/adafruit/Adafruit_CircuitPython_Requests>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
-**Board Compatibility:** The following built-in modules must be available: gc, json, ssl, time
+**Board Compatibility:** The following built-in modules must be available: gc, json, time
 
 Usage Example
 =============
@@ -73,8 +73,6 @@ To create an Azure IoT Hub instance or an Azure IoT Central app, you will need a
 
 ESP32 AirLift Networking
 ========================
-
-*NOTE* currently the ESP32 AirLift is not supported due to the requirment of `ssl`, which is only on boards with native WiFi.
 
 To use this library, you will need to create an ESP32_SPI WifiManager, connected to WiFi. You will also need to set the current time, as this is used to generate time-based authentication keys. One way to do this is with the following code:
 
@@ -96,7 +94,7 @@ To use this library, with boards that have native networking support, you need t
 
 .. code-block:: python
 
-    pool = socketpool.SocketPool(wifi.radio)
+    pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time

--- a/adafruit_azureiot/__init__.py
+++ b/adafruit_azureiot/__init__.py
@@ -21,15 +21,12 @@ Implementation Notes
 
 **With ESP32 Airlift Networking**
 
-* Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 * Adafruit's ESP32SPI library: https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
-* Adafruit's NTP library: https://github.com/adafruit/Adafruit_CircuitPython_NTP
 
 **With Native Networking**
 
 * CircuitPython's Wifi Module:
     https://docs.circuitpython.org/en/latest/shared-bindings/wifi/index.html
-* Adafruit's Requests Library: https://github.com/adafruit/Adafruit_CircuitPython_Requests/
 """
 
 from .iot_error import IoTError

--- a/adafruit_azureiot/device_registration.py
+++ b/adafruit_azureiot/device_registration.py
@@ -14,7 +14,6 @@ to IoT Central over MQTT
 """
 
 import json
-import ssl
 import time
 
 import adafruit_logging as logging
@@ -45,8 +44,8 @@ class DeviceRegistration:
     # pylint: disable=R0913
     def __init__(
         self,
-        socket,
-        iface,
+        socket_pool,
+        ssl_context,
         id_scope: str,
         device_id: str,
         device_sas_key: str,
@@ -74,8 +73,8 @@ class DeviceRegistration:
         self._operation_id = None
         self._hostname = None
 
-        self._socket = socket
-        self._iface = iface
+        self._socket_pool = socket_pool
+        self._ssl_context = ssl_context
 
     # pylint: disable=W0613
     # pylint: disable=C0103
@@ -202,8 +201,8 @@ class DeviceRegistration:
             client_id=self._device_id,
             is_ssl=True,
             keep_alive=120,
-            socket_pool=self._socket,
-            ssl_context=ssl.create_default_context(),
+            socket_pool=self._socket_pool,
+            ssl_context=self._ssl_context,
         )
 
         self._mqtt.enable_logger(logging, self._logger.getEffectiveLevel())

--- a/adafruit_azureiot/iot_mqtt.py
+++ b/adafruit_azureiot/iot_mqtt.py
@@ -14,7 +14,6 @@ An MQTT client for Azure IoT
 
 import gc
 import json
-import ssl
 import time
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
@@ -139,8 +138,8 @@ class IoTMQTT:
             client_id=self._device_id,
             is_ssl=True,
             keep_alive=120,
-            socket_pool=self._socket,
-            ssl_context=ssl.create_default_context(),
+            socket_pool=self._socket_pool,
+            ssl_context=self._ssl_context,
         )
 
         self._mqtts.enable_logger(logging, self._logger.getEffectiveLevel())
@@ -326,8 +325,8 @@ class IoTMQTT:
     def __init__(
         self,
         callback: IoTMQTTCallback,
-        socket,
-        iface,
+        socket_pool,
+        ssl_context,
         hostname: str,
         device_id: str,
         device_sas_key: str,
@@ -347,8 +346,8 @@ class IoTMQTT:
         :param Logger logger: The logger
         """
         self._callback = callback
-        self._socket = socket
-        self._iface = iface
+        self._socket_pool = socket_pool
+        self._ssl_context = ssl_context
         self._auth_response_received = False
         self._mqtts = None
         self._device_id = device_id

--- a/examples/azureiot_esp32spi/azureiot_central_commands.py
+++ b/examples/azureiot_esp32spi/azureiot_central_commands.py
@@ -8,7 +8,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -103,9 +103,15 @@ from adafruit_azureiot.iot_mqtt import IoTResponse
 
 # pylint: enable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
 device = IoTCentralDevice(
-    socket, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 

--- a/examples/azureiot_esp32spi/azureiot_central_commands.py
+++ b/examples/azureiot_esp32spi/azureiot_central_commands.py
@@ -96,7 +96,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 # pylint: disable=wrong-import-position
 from adafruit_azureiot import IoTCentralDevice
 from adafruit_azureiot.iot_mqtt import IoTResponse

--- a/examples/azureiot_esp32spi/azureiot_central_notconnected.py
+++ b/examples/azureiot_esp32spi/azureiot_central_notconnected.py
@@ -10,7 +10,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -99,9 +99,15 @@ from adafruit_azureiot import (
 
 # pylint: enable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
 device = IoTCentralDevice(
-    socket, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 # don't connect

--- a/examples/azureiot_esp32spi/azureiot_central_notconnected.py
+++ b/examples/azureiot_esp32spi/azureiot_central_notconnected.py
@@ -90,7 +90,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 # pylint: disable=wrong-import-position
 from adafruit_azureiot import (
     IoTCentralDevice,

--- a/examples/azureiot_esp32spi/azureiot_central_properties.py
+++ b/examples/azureiot_esp32spi/azureiot_central_properties.py
@@ -9,7 +9,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -100,9 +100,15 @@ print("Time:", str(time.time()))
 # * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTCentralDevice  # pylint: disable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
 device = IoTCentralDevice(
-    socket, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 

--- a/examples/azureiot_esp32spi/azureiot_central_properties.py
+++ b/examples/azureiot_esp32spi/azureiot_central_properties.py
@@ -97,7 +97,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTCentralDevice  # pylint: disable=wrong-import-position
 
 pool = adafruit_connection_manager.get_radio_socketpool(esp)

--- a/examples/azureiot_esp32spi/azureiot_central_simpletest.py
+++ b/examples/azureiot_esp32spi/azureiot_central_simpletest.py
@@ -98,7 +98,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTCentralDevice  # pylint: disable=wrong-import-position
 
 pool = adafruit_connection_manager.get_radio_socketpool(esp)

--- a/examples/azureiot_esp32spi/azureiot_central_simpletest.py
+++ b/examples/azureiot_esp32spi/azureiot_central_simpletest.py
@@ -10,7 +10,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -101,9 +101,15 @@ print("Time:", str(time.time()))
 # * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTCentralDevice  # pylint: disable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
 device = IoTCentralDevice(
-    socket, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 print("Connecting to Azure IoT Central...")

--- a/examples/azureiot_esp32spi/azureiot_hub_directmethods.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_directmethods.py
@@ -8,7 +8,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -97,8 +97,10 @@ from adafruit_azureiot.iot_mqtt import IoTResponse
 
 # pylint: enable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(socket, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to direct method calls

--- a/examples/azureiot_esp32spi/azureiot_hub_directmethods.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_directmethods.py
@@ -90,7 +90,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 # pylint: disable=wrong-import-position
 from adafruit_azureiot import IoTHubDevice
 from adafruit_azureiot.iot_mqtt import IoTResponse

--- a/examples/azureiot_esp32spi/azureiot_hub_messages.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_messages.py
@@ -92,7 +92,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
 pool = adafruit_connection_manager.get_radio_socketpool(esp)

--- a/examples/azureiot_esp32spi/azureiot_hub_messages.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_messages.py
@@ -10,7 +10,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -95,8 +95,10 @@ print("Time:", str(time.time()))
 # * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(socket, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to cloud to device messages

--- a/examples/azureiot_esp32spi/azureiot_hub_simpletest.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_simpletest.py
@@ -92,7 +92,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
 pool = adafruit_connection_manager.get_radio_socketpool(esp)

--- a/examples/azureiot_esp32spi/azureiot_hub_simpletest.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_simpletest.py
@@ -10,7 +10,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -95,8 +95,10 @@ print("Time:", str(time.time()))
 # * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(socket, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 print("Connecting to Azure IoT Hub...")
 

--- a/examples/azureiot_esp32spi/azureiot_hub_twin_operations.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_twin_operations.py
@@ -9,7 +9,7 @@ from digitalio import DigitalInOut
 import neopixel
 import rtc
 from adafruit_esp32spi import adafruit_esp32spi, adafruit_esp32spi_wifimanager
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -97,8 +97,10 @@ print("Time:", str(time.time()))
 # * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(socket, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to device twin desired property updates

--- a/examples/azureiot_esp32spi/azureiot_hub_twin_operations.py
+++ b/examples/azureiot_esp32spi/azureiot_hub_twin_operations.py
@@ -94,7 +94,6 @@ print("Time:", str(time.time()))
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 from adafruit_azureiot import IoTHubDevice  # pylint: disable=wrong-import-position
 
 pool = adafruit_connection_manager.get_radio_socketpool(esp)

--- a/examples/azureiot_native_networking/azureiot_central_commands.py
+++ b/examples/azureiot_native_networking/azureiot_central_commands.py
@@ -67,7 +67,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_central_commands.py
+++ b/examples/azureiot_native_networking/azureiot_central_commands.py
@@ -4,9 +4,9 @@
 import time
 
 import rtc
-import socketpool
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTCentralDevice
 from adafruit_azureiot.iot_mqtt import IoTResponse
@@ -21,11 +21,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -69,10 +71,12 @@ else:
 
 
 # Create an IoT Hub device client and connect
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 device = IoTCentralDevice(
-    pool, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 

--- a/examples/azureiot_native_networking/azureiot_central_notconnected.py
+++ b/examples/azureiot_native_networking/azureiot_central_notconnected.py
@@ -6,9 +6,9 @@ import random
 import time
 
 import rtc
-import socketpool
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import (
     IoTCentralDevice,
@@ -25,11 +25,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -73,10 +75,12 @@ else:
 
 
 # Create an IoT Hub device client and connect
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 device = IoTCentralDevice(
-    pool, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 # don't connect

--- a/examples/azureiot_native_networking/azureiot_central_notconnected.py
+++ b/examples/azureiot_native_networking/azureiot_central_notconnected.py
@@ -71,7 +71,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_central_properties.py
+++ b/examples/azureiot_native_networking/azureiot_central_properties.py
@@ -67,7 +67,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_central_properties.py
+++ b/examples/azureiot_native_networking/azureiot_central_properties.py
@@ -5,9 +5,9 @@ import random
 import time
 
 import rtc
-import socketpool
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTCentralDevice
 
@@ -21,11 +21,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -69,10 +71,12 @@ else:
 
 
 # Create an IoT Hub device client and connect
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 device = IoTCentralDevice(
-    pool, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 

--- a/examples/azureiot_native_networking/azureiot_central_simpletest.py
+++ b/examples/azureiot_native_networking/azureiot_central_simpletest.py
@@ -68,7 +68,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_central_simpletest.py
+++ b/examples/azureiot_native_networking/azureiot_central_simpletest.py
@@ -6,9 +6,9 @@ import random
 import time
 
 import rtc
-import socketpool
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTCentralDevice
 
@@ -22,11 +22,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -70,10 +72,12 @@ else:
 
 
 # Create an IoT Hub device client and connect
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 device = IoTCentralDevice(
-    pool, esp, secrets["id_scope"], secrets["device_id"], secrets["device_sas_key"]
+    pool,
+    ssl_context,
+    secrets["id_scope"],
+    secrets["device_id"],
+    secrets["device_sas_key"],
 )
 
 print("Connecting to Azure IoT Central...")

--- a/examples/azureiot_native_networking/azureiot_hub_directmethods.py
+++ b/examples/azureiot_native_networking/azureiot_hub_directmethods.py
@@ -61,7 +61,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_hub_directmethods.py
+++ b/examples/azureiot_native_networking/azureiot_hub_directmethods.py
@@ -3,10 +3,10 @@
 
 import time
 
-import socketpool
 import rtc
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTHubDevice
 from adafruit_azureiot.iot_mqtt import IoTResponse
@@ -21,11 +21,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -62,10 +64,8 @@ else:
 # * adafruit-circuitpython-requests
 
 
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(pool, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to direct method calls

--- a/examples/azureiot_native_networking/azureiot_hub_messages.py
+++ b/examples/azureiot_native_networking/azureiot_hub_messages.py
@@ -62,7 +62,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_hub_messages.py
+++ b/examples/azureiot_native_networking/azureiot_hub_messages.py
@@ -5,10 +5,10 @@ import json
 import random
 import time
 
-import socketpool
 import rtc
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTHubDevice
 
@@ -22,11 +22,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -63,10 +65,8 @@ else:
 # * adafruit-circuitpython-requests
 
 
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(pool, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to cloud to device messages

--- a/examples/azureiot_native_networking/azureiot_hub_simpletest.py
+++ b/examples/azureiot_native_networking/azureiot_hub_simpletest.py
@@ -5,10 +5,10 @@ import json
 import random
 import time
 
-import socketpool
 import rtc
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTHubDevice
 
@@ -22,11 +22,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -63,10 +65,8 @@ else:
 # * adafruit-circuitpython-requests
 
 
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(pool, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 print("Connecting to Azure IoT Hub...")
 

--- a/examples/azureiot_native_networking/azureiot_hub_simpletest.py
+++ b/examples/azureiot_native_networking/azureiot_hub_simpletest.py
@@ -62,7 +62,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_hub_twin_operations.py
+++ b/examples/azureiot_native_networking/azureiot_hub_twin_operations.py
@@ -61,7 +61,6 @@ else:
 #
 # From the Adafruit CircuitPython Bundle https://github.com/adafruit/Adafruit_CircuitPython_Bundle:
 # * adafruit-circuitpython-minimqtt
-# * adafruit-circuitpython-requests
 
 
 # Create an IoT Hub device client and connect

--- a/examples/azureiot_native_networking/azureiot_hub_twin_operations.py
+++ b/examples/azureiot_native_networking/azureiot_hub_twin_operations.py
@@ -4,10 +4,10 @@
 import random
 import time
 
-import socketpool
 import rtc
 import wifi
 
+import adafruit_connection_manager
 import adafruit_ntp
 from adafruit_azureiot import IoTHubDevice
 
@@ -21,11 +21,13 @@ except ImportError:
 print("Connecting to WiFi...")
 wifi.radio.connect(secrets["ssid"], secrets["password"])
 
+pool = adafruit_connection_manager.get_radio_socketpool(wifi.radio)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(wifi.radio)
+
 print("Connected to WiFi!")
 
 if time.localtime().tm_year < 2022:
     print("Setting System Time in UTC")
-    pool = socketpool.SocketPool(wifi.radio)
     ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
     # NOTE: This changes the system time so make sure you aren't assuming that time
@@ -62,10 +64,8 @@ else:
 # * adafruit-circuitpython-requests
 
 
-esp = None
-pool = socketpool.SocketPool(wifi.radio)
 # Create an IoT Hub device client and connect
-device = IoTHubDevice(pool, esp, secrets["device_connection_string"])
+device = IoTHubDevice(pool, ssl_context, secrets["device_connection_string"])
 
 
 # Subscribe to device twin desired property updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@
 Adafruit-Blinka
 adafruit-circuitpython-logging>=4.0.1
 adafruit-circuitpython-minimqtt
-adafruit-circuitpython-requests
 adafruit-circuitpython-binascii


### PR DESCRIPTION
Updates to `adafruit_azureiot/device_registration.py` and `adafruit_azureiot/iot_mqtt.py` to take passed in `ssl_context`. This adds support back for ESP32SPI.

Tested a few examples, this was my main testing routine (toggling `USE_ONBOARD`). Tested using a `UM FeatherS3` + `AirLift Featherwing` (for ESP32SPI tests):

```py
USE_ONBOARD = True

import json
import os
import rtc
import supervisor
import time

import adafruit_connection_manager
import adafruit_logging
import adafruit_ntp
from adafruit_azureiot import IoTCentralDevice


wifi_ssid = os.getenv("CIRCUITPY_WIFI_SSID")
wifi_password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
azure_id_scope = os.getenv("AZURE_ID_SCOPE")
azure_device_id = os.getenv("AZURE_DEVICE_ID")
azure_primary_key = os.getenv("AZURE_PRIMARY_KEY")

print("Connecting to WiFi...")
if USE_ONBOARD:
    print("Using on-board")
    import wifi

    radio = wifi.radio
    radio.connect(wifi_ssid, wifi_password)

else:
    print("Using esp32spi")
    import board
    import busio
    import digitalio
    from adafruit_esp32spi.adafruit_esp32spi import ESP_SPIcontrol

    esp32_cs = digitalio.DigitalInOut(board.D13)
    esp32_ready = digitalio.DigitalInOut(board.D11)
    esp32_reset = digitalio.DigitalInOut(board.D12)
    spi_bus = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
    radio = ESP_SPIcontrol(spi_bus, esp32_cs, esp32_ready, esp32_reset)
    radio.connect_AP(wifi_ssid, wifi_password)
print("Connected to WiFi!")

pool = adafruit_connection_manager.get_radio_socketpool(radio)
ssl_context = adafruit_connection_manager.get_radio_ssl_context(radio)

def get_time():
    if USE_ONBOARD:
        ntp = adafruit_ntp.NTP(pool)
        rtc.RTC().datetime = ntp.datetime
    else:
        now = radio.get_time()
        now = time.localtime(now[0])
        rtc.RTC().datetime = now
    print(rtc.RTC().datetime)


if time.localtime().tm_year < 2022:
    print("Setting System Time in UTC")
    # asking for time right after connecting the esp32spi often fails
    time.sleep(5)
    get_time()
else:
    print("Year seems good, skipping set time.")

device = IoTCentralDevice(pool, ssl_context, azure_id_scope, azure_device_id, azure_primary_key)

print("Connecting to Azure IoT Central...")
device.connect()
print("Connected to Azure IoT Central!")

azure_clock = 0
i = 0

while True:
    try:
        if azure_clock >= 10:
            i += 1
            print("getting ntp date/time")
            get_time()
            time.sleep(2)
            print("getting msg")
            message = {"value": i, "use_onboard": USE_ONBOARD}
            print(f"sending json: {message}")
            device.send_telemetry(json.dumps(message))
            print("data sent")
            azure_clock = 0
        else:
            azure_clock += 1
        device.loop()

    except (ValueError, RuntimeError, OSError, ConnectionError) as e:
        print("Network error, reconnecting\n", str(e))
        supervisor.reload()
        continue

    time.sleep(1)
    print(azure_clock)
```

fixes #55